### PR TITLE
Feature/test: agregar pruebas unitarias y mocks a TaskItemService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# TaskFlow Data
+tasks.json

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Para correr esta aplicación en tu entorno local, sigue estos pasos:
 5. **Ejecutar la aplicación:**
    Si usas la terminal de .NET, ejecuta: `dotnet run`
 
+## 🧪 Pruebas Unitarias
+
+El proyecto incluye una suite de pruebas profesional utilizando **xUnit** y **FluentAssertions**. 
+
+Para ejecutar las pruebas, utiliza el siguiente comando desde la raíz:
+```bash
+dotnet test
+```
+
+La cobertura incluye:
+- Validación de modelos (`TaskItem`)
+- Lógica de servicios (`TaskItemService`)
+- Casos de borde y manejo de excepciones.
+
 ## 👥 Integrantes del Equipo
 
 - **Alejandro Luna** - Rol: A discutir

--- a/src/TaskFlow/Services/FileManager.cs
+++ b/src/TaskFlow/Services/FileManager.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace TaskFlow.Services;
+
+public class FileManager : IFileManager
+{
+    public void WriteAllText(string path, string contents)
+    {
+        File.WriteAllText(path, contents);
+    }
+}

--- a/src/TaskFlow/Services/IFileManager.cs
+++ b/src/TaskFlow/Services/IFileManager.cs
@@ -1,0 +1,6 @@
+namespace TaskFlow.Services;
+
+public interface IFileManager
+{
+    void WriteAllText(string path, string contents);
+}

--- a/src/TaskFlow/Services/TaskItemService.cs
+++ b/src/TaskFlow/Services/TaskItemService.cs
@@ -6,9 +6,12 @@ namespace TaskFlow.Services;
 public class TaskItemService
 {
     private readonly List<TaskItem> _tasks = new ();
-    public TaskItemService()
+    private readonly IFileManager _fileManager;
+
+    public TaskItemService(IFileManager? fileManager = null)
     {
         _tasks = new List<TaskItem>();
+        _fileManager = fileManager ?? new FileManager();
     }
     public void CreateTask(string title, string description, string responsible) //Método para crear una tarea con título, descripción y responsable
     {
@@ -57,6 +60,6 @@ public class TaskItemService
         task.UpdatedAt = DateTime.UtcNow;
 
         var options = new JsonSerializerOptions { WriteIndented = true };
-        File.WriteAllText("tasks.json", JsonSerializer.Serialize(_tasks, options));
+        _fileManager.WriteAllText("tasks.json", JsonSerializer.Serialize(_tasks, options));
     }
 }

--- a/src/TaskFlow/Services/TaskItemService.cs
+++ b/src/TaskFlow/Services/TaskItemService.cs
@@ -12,6 +12,9 @@ public class TaskItemService
     }
     public void CreateTask(string title, string description, string responsible) //Método para crear una tarea con título, descripción y responsable
     {
+        if (string.IsNullOrWhiteSpace(title)) throw new ArgumentException("El título de la tarea no puede estar vacío.");
+        if (string.IsNullOrWhiteSpace(responsible)) throw new ArgumentException("El responsable de la tarea no puede estar vacío.");
+
         var newTask = new TaskItem
         {
             Id = _tasks.Count + 1, //Cuando agreguemos filemanager, tasks será la inyección de la base de datos, por ahora es la lista en memoria
@@ -26,6 +29,9 @@ public class TaskItemService
 
     public void CreateTask(string title, string responsible) //Sobrecarga del método CreateTask para permitir crear tareas sin descripción
     {
+        if (string.IsNullOrWhiteSpace(title)) throw new ArgumentException("El título de la tarea no puede estar vacío.");
+        if (string.IsNullOrWhiteSpace(responsible)) throw new ArgumentException("El responsable de la tarea no puede estar vacío.");
+
         var newTask = new TaskItem
         {
             Id = _tasks.Count + 1,

--- a/taskflow.csproj
+++ b/taskflow.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefaultItemExcludes>test\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/taskflow.csproj
+++ b/taskflow.csproj
@@ -7,4 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="test\**" />
+    <EmbeddedResource Remove="test\**" />
+    <None Remove="test\**" />
+  </ItemGroup>
+
 </Project>

--- a/taskflow.csproj
+++ b/taskflow.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DefaultItemExcludes>test\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/taskflow.sln
+++ b/taskflow.sln
@@ -1,22 +1,54 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "taskflow", "taskflow.csproj", "{457D5A95-A093-D3DD-914D-DFBF668566D5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskFlow.Tests", "test\TaskFlow.Tests.csproj", "{200D21F0-05AC-4781-A61F-F3B139196D09}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|x64.Build.0 = Debug|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Debug|x86.Build.0 = Debug|Any CPU
 		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|x64.ActiveCfg = Release|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|x64.Build.0 = Release|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|x86.ActiveCfg = Release|Any CPU
+		{457D5A95-A093-D3DD-914D-DFBF668566D5}.Release|x86.Build.0 = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|x64.Build.0 = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Debug|x86.Build.0 = Debug|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|x64.ActiveCfg = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|x64.Build.0 = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|x86.ActiveCfg = Release|Any CPU
+		{200D21F0-05AC-4781-A61F-F3B139196D09}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{200D21F0-05AC-4781-A61F-F3B139196D09} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A34912CD-018B-4D3D-ABC6-2170F5FC9407}

--- a/test/TaskFlow.Tests.csproj
+++ b/test/TaskFlow.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/TaskFlow.Tests.csproj
+++ b/test/TaskFlow.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/test/TaskFlow.Tests.csproj
+++ b/test/TaskFlow.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\taskflow.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TaskItemTests.cs
+++ b/test/TaskItemTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using TaskFlow.Models;
+using Xunit;
+
+namespace TaskFlow.Tests;
+
+/// <summary>
+/// Proporciona pruebas unitarias para la clase <see cref="TaskItem"/>.
+/// </summary>
+public class TaskItemTests
+{
+    /// <summary>
+    /// Valida que un objeto <see cref="TaskItem"/> se pueda crear correctamente con valores válidos.
+    /// </summary>
+    /// <returns>Nada (procedimiento de prueba).</returns>
+    [Fact]
+    public void TaskItem_ShouldInitializeCorrectly_WhenProvidedValidData()
+    {
+        // Arrange
+        var id = 1;
+        var title = "Implementar Tests";
+        var description = "Crear suite de pruebas para TaskItem";
+        var responsible = "QA Team";
+        var status = TaskStatus.ToDo;
+        var createdAt = DateTime.UtcNow;
+
+        // Act
+        var taskItem = new TaskItem
+        {
+            Id = id,
+            Title = title,
+            Description = description,
+            Responsible = responsible,
+            Status = status,
+            CreatedAt = createdAt
+        };
+
+        // Assert
+        taskItem.Id.Should().Be(id);
+        taskItem.Title.Should().Be(title);
+        taskItem.Description.Should().Be(description);
+        taskItem.Responsible.Should().Be(responsible);
+        taskItem.Status.Should().Be(status);
+        taskItem.CreatedAt.Should().Be(createdAt);
+    }
+
+    /// <summary>
+    /// Valida el comportamiento cuando se asigna un título vacío.
+    /// </summary>
+    /// <returns>Nada (procedimiento de prueba).</returns>
+    [Fact]
+    public void TaskItem_Title_CanBeEmpty()
+    {
+        // Arrange
+        var taskItem = new TaskItem();
+
+        // Act
+        taskItem.Title = string.Empty;
+
+        // Assert
+        taskItem.Title.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Valida que el tiempo de creación por defecto sea reciente.
+    /// </summary>
+    /// <returns>Nada (procedimiento de prueba).</returns>
+    [Fact]
+    public void TaskItem_CreatedAt_ShouldHaveDefaultValueNearNow()
+    {
+        // Arrange & Act
+        var taskItem = new TaskItem();
+
+        // Assert
+        taskItem.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, precision: TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Valida el manejo de IDs negativos.
+    /// </summary>
+    /// <returns>Nada (procedimiento de prueba).</returns>
+    [Fact]
+    public void TaskItem_Id_ShouldAllowNegativeValues()
+    {
+        // Arrange
+        var taskItem = new TaskItem();
+        var negativeId = -1;
+
+        // Act
+        taskItem.Id = negativeId;
+
+        // Assert
+        taskItem.Id.Should().Be(negativeId);
+    }
+
+    /// <summary>
+    /// Valida que UpdatedAt pueda ser nulo inicialmente.
+    /// </summary>
+    /// <returns>Nada (procedimiento de prueba).</returns>
+    [Fact]
+    public void TaskItem_UpdatedAt_ShouldBeNullByDefault()
+    {
+        // Arrange & Act
+        var taskItem = new TaskItem();
+
+        // Assert
+        taskItem.UpdatedAt.Should().BeNull();
+    }
+}

--- a/test/TaskServiceTests.cs
+++ b/test/TaskServiceTests.cs
@@ -74,4 +74,36 @@ public class TaskServiceTests
         // Assert
         action.Should().Throw<ArgumentException>().WithMessage("Tarea no encontrada.");
     }
+
+    /// <summary>
+    /// Valida que se lance una excepción cuando el título está vacío.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void CreateTask_ShouldThrowArgumentException_WhenTitleIsInvalid(string invalidTitle)
+    {
+        // Act
+        var action = () => _service.CreateTask(invalidTitle, "Responsable");
+
+        // Assert
+        action.Should().Throw<ArgumentException>().WithMessage("El título de la tarea no puede estar vacío.");
+    }
+
+    /// <summary>
+    /// Valida que se lance una excepción cuando el responsable está vacío.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void CreateTask_ShouldThrowArgumentException_WhenResponsibleIsInvalid(string invalidResponsible)
+    {
+        // Act
+        var action = () => _service.CreateTask("Título", invalidResponsible);
+
+        // Assert
+        action.Should().Throw<ArgumentException>().WithMessage("El responsable de la tarea no puede estar vacío.");
+    }
 }

--- a/test/TaskServiceTests.cs
+++ b/test/TaskServiceTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Text.Json;
 using FluentAssertions;
+using Moq;
 using TaskFlow.Models;
 using TaskFlow.Services;
 using Xunit;
@@ -10,18 +13,20 @@ namespace TaskFlow.Tests;
 /// </summary>
 public class TaskServiceTests
 {
+    private readonly Mock<IFileManager> _fileManagerMock;
     private readonly TaskItemService _service;
 
     public TaskServiceTests()
     {
-        _service = new TaskItemService();
+        _fileManagerMock = new Mock<IFileManager>();
+        _service = new TaskItemService(_fileManagerMock.Object);
     }
 
     /// <summary>
-    /// Valida que una tarea se cree correctamente y se agregue a la lista.
+    /// Valida que una tarea con todos los datos válidos se cree correctamente y se agregue a la lista.
     /// </summary>
     [Fact]
-    public void CreateTask_ShouldAddTaskToList_WhenDataIsValid()
+    public void CreateTask_ValidData_ShouldAddTaskToList()
     {
         // Arrange
         var title = "Test Task";
@@ -41,10 +46,32 @@ public class TaskServiceTests
     }
 
     /// <summary>
-    /// Valida que el estado de una tarea se actualice correctamente.
+    /// Valida que una tarea sin descripción se cree correctamente y se agregue a la lista.
     /// </summary>
     [Fact]
-    public void UpdateTaskStatus_ShouldUpdateStatusAndUpdatedAt_WhenTaskExists()
+    public void CreateTask_ValidDataWithoutDescription_ShouldAddTaskToList()
+    {
+        // Arrange
+        var title = "Test Task";
+        var responsible = "QA";
+
+        // Act
+        _service.CreateTask(title, responsible);
+        var tasks = _service.ListTasks();
+
+        // Assert
+        tasks.Should().HaveCount(1);
+        tasks[0].Title.Should().Be(title);
+        tasks[0].Description.Should().BeNull();
+        tasks[0].Responsible.Should().Be(responsible);
+        tasks[0].Status.Should().Be(TaskStatus.ToDo);
+    }
+
+    /// <summary>
+    /// Valida que el estado de una tarea se actualice correctamente y se guarde en archivo usando la dependencia externa.
+    /// </summary>
+    [Fact]
+    public void UpdateTaskStatus_ValidId_ShouldUpdateStatusAndCallFileManager()
     {
         // Arrange
         _service.CreateTask("Task 1", "Responsible 1");
@@ -57,13 +84,18 @@ public class TaskServiceTests
         // Assert
         task.Status.Should().Be(newStatus);
         task.UpdatedAt.Should().NotBeNull();
+        
+        // Verifica que se haya llamado a la dependencia externa para persistir los cambios
+        _fileManagerMock.Verify(f => f.WriteAllText(
+            It.Is<string>(path => path == "tasks.json"), 
+            It.IsAny<string>()), Times.Once);
     }
 
     /// <summary>
     /// Valida que se lance una excepción cuando se intenta actualizar una tarea inexistente.
     /// </summary>
     [Fact]
-    public void UpdateTaskStatus_ShouldThrowArgumentException_WhenTaskDoesNotExist()
+    public void UpdateTaskStatus_NonExistentId_ShouldThrowArgumentException()
     {
         // Arrange
         var invalidId = 999;
@@ -73,37 +105,44 @@ public class TaskServiceTests
 
         // Assert
         action.Should().Throw<ArgumentException>().WithMessage("Tarea no encontrada.");
+        
+        // Verifica que NO se haya llamado a la dependencia externa ya que la operación falló
+        _fileManagerMock.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>
-    /// Valida que se lance una excepción cuando el título está vacío.
+    /// Valida que se lance una excepción cuando el título es nulo o vacío.
     /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     [InlineData(null)]
-    public void CreateTask_ShouldThrowArgumentException_WhenTitleIsInvalid(string invalidTitle)
+    public void CreateTask_NullOrEmptyTitle_ShouldThrowArgumentException(string? invalidTitle)
     {
         // Act
-        var action = () => _service.CreateTask(invalidTitle, "Responsable");
+        var action1 = () => _service.CreateTask(invalidTitle, "Description", "Responsable");
+        var action2 = () => _service.CreateTask(invalidTitle, "Responsable");
 
         // Assert
-        action.Should().Throw<ArgumentException>().WithMessage("El título de la tarea no puede estar vacío.");
+        action1.Should().Throw<ArgumentException>().WithMessage("El título de la tarea no puede estar vacío.");
+        action2.Should().Throw<ArgumentException>().WithMessage("El título de la tarea no puede estar vacío.");
     }
 
     /// <summary>
-    /// Valida que se lance una excepción cuando el responsable está vacío.
+    /// Valida que se lance una excepción cuando el responsable es nulo o vacío.
     /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     [InlineData(null)]
-    public void CreateTask_ShouldThrowArgumentException_WhenResponsibleIsInvalid(string invalidResponsible)
+    public void CreateTask_NullOrEmptyResponsible_ShouldThrowArgumentException(string? invalidResponsible)
     {
         // Act
-        var action = () => _service.CreateTask("Título", invalidResponsible);
+        var action1 = () => _service.CreateTask("Título", "Description", invalidResponsible);
+        var action2 = () => _service.CreateTask("Título", invalidResponsible);
 
         // Assert
-        action.Should().Throw<ArgumentException>().WithMessage("El responsable de la tarea no puede estar vacío.");
+        action1.Should().Throw<ArgumentException>().WithMessage("El responsable de la tarea no puede estar vacío.");
+        action2.Should().Throw<ArgumentException>().WithMessage("El responsable de la tarea no puede estar vacío.");
     }
 }

--- a/test/TaskServiceTests.cs
+++ b/test/TaskServiceTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using TaskFlow.Models;
+using TaskFlow.Services;
+using Xunit;
+
+namespace TaskFlow.Tests;
+
+/// <summary>
+/// Proporciona pruebas unitarias para la clase <see cref="TaskItemService"/>.
+/// </summary>
+public class TaskServiceTests
+{
+    private readonly TaskItemService _service;
+
+    public TaskServiceTests()
+    {
+        _service = new TaskItemService();
+    }
+
+    /// <summary>
+    /// Valida que una tarea se cree correctamente y se agregue a la lista.
+    /// </summary>
+    [Fact]
+    public void CreateTask_ShouldAddTaskToList_WhenDataIsValid()
+    {
+        // Arrange
+        var title = "Test Task";
+        var description = "Description";
+        var responsible = "QA";
+
+        // Act
+        _service.CreateTask(title, description, responsible);
+        var tasks = _service.ListTasks();
+
+        // Assert
+        tasks.Should().HaveCount(1);
+        tasks[0].Title.Should().Be(title);
+        tasks[0].Description.Should().Be(description);
+        tasks[0].Responsible.Should().Be(responsible);
+        tasks[0].Status.Should().Be(TaskStatus.ToDo);
+    }
+
+    /// <summary>
+    /// Valida que el estado de una tarea se actualice correctamente.
+    /// </summary>
+    [Fact]
+    public void UpdateTaskStatus_ShouldUpdateStatusAndUpdatedAt_WhenTaskExists()
+    {
+        // Arrange
+        _service.CreateTask("Task 1", "Responsible 1");
+        var task = _service.ListTasks()[0];
+        var newStatus = TaskStatus.InProgress;
+
+        // Act
+        _service.UpdateTaskStatus(task.Id, newStatus);
+
+        // Assert
+        task.Status.Should().Be(newStatus);
+        task.UpdatedAt.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Valida que se lance una excepción cuando se intenta actualizar una tarea inexistente.
+    /// </summary>
+    [Fact]
+    public void UpdateTaskStatus_ShouldThrowArgumentException_WhenTaskDoesNotExist()
+    {
+        // Arrange
+        var invalidId = 999;
+
+        // Act
+        var action = () => _service.UpdateTaskStatus(invalidId, TaskStatus.Done);
+
+        // Assert
+        action.Should().Throw<ArgumentException>().WithMessage("Tarea no encontrada.");
+    }
+}


### PR DESCRIPTION
aca subo los tests q faltaban para la clase TaskItemService.

para poder aislar todo y hacer mocks de verdad (que sea unitario 100% y no de integracion), tuve que refactorizar un toque el servicio. El problema era q UpdateTaskStatus le pegaba directo al disco con File.WriteAllText. Asi que hice una interfaz rapida IFileManager y se la meti al constructor de la clase para poder mockearla tranca con Moq.

resumen de lo q hice:

agregue tests para la creacion de tareas (con y sin descripcion).

test para actualizar el estado de la tarea (y q verifique que llama al archivo mockeado).

meti las validaciones de las excepciones, onda q pase nulls o id q no existen.

aplique el patron ese de Arrange-Act-Assert.

tmb le agregue el paquete de moq al proyecto de test xq no estaba. cualquier cosa si rompe algo me avisan y lo corrijo.